### PR TITLE
Travis CI to build and deploy docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: python
+python:
+  - '3.4'
+sudo: false
+before_install:
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/miniconda/bin:$PATH
+  - conda update --yes conda
+install:
+  - conda create --yes -q -n pyenv python=$TRAVIS_PYTHON_VERSION sphinx
+  - source activate pyenv
+script:
+  - |
+    test "${TRAVIS_BUILD_NUMBER}.1" == "${TRAVIS_JOB_NUMBER}" && \
+    (cd ./doc/sphinx && make clean html)
+after_success:
+  - |
+    test ${TRAVIS_PULL_REQUEST} == "false" && \
+    test ${TRAVIS_BRANCH} == ${GH_DOC_BRANCH} && \
+    test "${TRAVIS_BUILD_NUMBER}.1" == "${TRAVIS_JOB_NUMBER}" && \
+    bash ./ci/deploy_docs.sh
+env:
+  global:
+    - secure: aNUISxbQ26DD+sf7ARuLfWEpmsx0kjHrqRIXRjWZbT8dJWzQ+gbJJKYfjkoPHtZgo5nfRYEhWwIHj8Ux4lE8mnfYnWnyCTArtbsQp2oiFhvi4HDG8S3pIAeC19cDwaj5BxdU0u448YoV53qbjAJTLoVR5yaBguWUWWJ7nwR3Roo=
+    - GH_DOC_BRANCH: master
+    - GH_REPOSITORY: github.com/MDAnalysis/MDAnalysisTutorial.git
+    - GIT_CI_USER: TravisCI
+    - GIT_CI_EMAIL: TravisCI@mdanalysis.org
+    - MDA_DOCDIR: doc/pages/html

--- a/ci/deploy_docs.sh
+++ b/ci/deploy_docs.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Deploying docs from travis-ci.
+# See https://github.com/MDAnalysis/mdanalysis/issues/386
+# Script based on https://github.com/steveklabnik/automatically_update_github_pages_with_travis_example
+
+# Run this script from the top-level of the checked out git
+# repository. A github OAuth token must be available in the evironment
+# variable GH_TOKEN and is set up through the .travis.yml
+# env:global:secure parameter (encrypted with travis-ci's public key)/
+#
+# Additional environment variables set in .travis.yml
+#  GH_REPOSITORY     repo to full from and push to
+#  GH_DOC_BRANCH     branch from which the docs are built
+#  GIT_CI_USER       name of the user to push docs as
+#  GIT_CI_EMAIL      email of the user to push docs as
+#  MDA_DOCDIR        path to the docdir from top of repo
+#
+# NOTE: If any of these environment variables are not set or 
+#       empty then the script will exit with an error (-o nounset).
+
+set -o errexit -o nounset
+
+function die () {
+    local msg="$1" err={$2:-1}
+    echo "ERROR: $msg [$err]"
+    exit $err
+}
+
+rev=$(git rev-parse --short HEAD)
+
+# the following tests should be superfluous because of -o nounset
+test -n "${GH_TOKEN}" || die "GH_TOKEN is empty: need OAuth GitHub token to continue" 100
+test -n "${GH_REPOSITORY}" || die "GH_REPOSITORY must be set in .travis.yml" 100
+test -n "${MDA_DOCDIR}" || die "MDA_DOCDIR must be set in .travis.yml" 100
+
+cd ${MDA_DOCDIR} || die "Failed to 'cd ${MDA_DOCDIR}'. Run from the top level of the repository"
+
+git init
+git config user.name "${GIT_CI_USER}"
+git config user.email "${GIT_CI_EMAIL}"
+
+git remote add upstream "https://${GH_TOKEN}@${GH_REPOSITORY}"
+git fetch --depth 50 upstream ${GH_DOC_BRANCH} gh-pages
+git reset upstream/gh-pages
+
+touch .
+touch .nojekyll
+
+git add -A .
+git commit -m "rebuilt html docs from branch ${GH_DOC_BRANCH} with sphinx at ${rev}"
+git push -q upstream HEAD:gh-pages
+
+


### PR DESCRIPTION
Copied travis config and deploy_docs.sh from MDAnalysis/GridDataFormats and
adjusted slightly so that a new commit automatically builds the sphinx docs
on Travis CI and pushes it to the gh-pages branch which then appears
immediately at http://mdanalysis.org/MDAnalysisTutorial